### PR TITLE
Add Tech stack icons instead of just names in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- <a name="readme-top"></a> -->
 <br/>
 <p align="center">
   <h1 align="center">Spendwise</h1>
@@ -40,22 +41,24 @@ We would love to hear from you! We communicate on Slack:
 
 
 Spendwise: Your intuitive, user-friendly expense tracker. Seamlessly manage and understand your finances with simplicity and precision. Track, analyze, and take control of your expenses effortlessly.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## Built With
 
 Spendwise is powered by a modern tech stack:
 
-**React:** Dynamic user interfaces.
+* [![REACT][React.com]][React-url] : Dynamic user interfaces.
 
-**Node.js:** Efficient server-side scripting.
+* [![NODEJS][nodejs.com]][nodejs-url] : Efficient server-side scripting.
 
-**Express.js:** Streamlined API development.
+* [![EXPRESS][express.com]][express-url] : Streamlined API development.
 
-**MongoDB:** User profile and authentication.
+* [![MONGODB][mongodb.com]][mongodb-url] : User profile and authentication.
 
-**Firebase:** Real-time handling of the transactions of the users.
+* [![FIREBASE][firebase.com]][firebase-url] : Real-time handling of the transactions of the users.
 
 This combination ensures a seamless and powerful expense tracking experience.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 
 ## Getting Started
@@ -125,7 +128,7 @@ npm run dev
 
 The server will be running on http://localhost:3000
 
-
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## Ideas List
 
@@ -149,7 +152,7 @@ The server will be running on http://localhost:3000
    - Implement consistent coding standards and practices for improved readability and maintainability.
    - Create thorough documentation covering project architecture, API endpoints, and key code modules.
 
-
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 ## Authors
 
 * [Ankit Kumar Chowdhury](https://github.com/ani1609) - *Organisation Admin*
@@ -160,3 +163,16 @@ The server will be running on http://localhost:3000
 <a href="https://github.com/ani1609/Spendwise/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=ani1609/Spendwise" />
 </a>
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+<!-- MARKDOWN LINKS & IMAGES -->
+[React.com]:https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB
+[React-url]:https://react.dev/
+[nodejs.com]:https://img.shields.io/badge/Node.js-43853D?style=for-the-badge&logo=node.js&logoColor=white
+[nodejs-url]:https://nodejs.org/en
+[express.com]:https://img.shields.io/badge/Express.js-404D59?style=for-the-badge
+[express-url]:https://expressjs.com/
+[mongodb.com]:https://img.shields.io/badge/MongoDB-4EA94B?style=for-the-badge&logo=mongodb&logoColor=white
+[mongodb-url]:https://www.mongodb.com/
+[firebase.com]:https://img.shields.io/badge/Firebase-039BE5?style=for-the-badge&logo=Firebase&logoColor=white
+[firebase-url]:https://firebase.google.com/


### PR DESCRIPTION
## Pull Request

**Related Issues:**
Regarding the fix in the Readme file

Fixes #156

**Description:**
I added tech stack icons to the README instead of just listing their names. Additionally, I included a 'back to top' button in different sections of the README file. When clicked, this button will take you to the top of the README file.

**Checklist:**
- [x] I have tested my changes.
- [x] My code follows the project's coding standards.
- [ ] I have updated the documentation (if applicable).

**Screenshots:**
![Screenshot (3)](https://github.com/DevHrithik/Spendwise/assets/64660895/026ec9d7-e28f-489b-8370-07048ad1afad)


